### PR TITLE
Add basic extraction log parsing feeding into stream load wait logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ pytest
 
 ### Setup
 
-To use the library, you must configure a `stitch` resource in your Dagster instance. The resource requires a `client_id` and `client_secret` to authenticate with Stitch. You can find these values in the Stitch UI under `Settings > API Keys`.
+To use the library, you must configure a `stitch` resource in your Dagster instance. The resource requires an `api_key` to authenticate with Stitch. You can find or generate one in the Stitch UI under `Account Settings > API Access Keys`.
 
 You will also need to note your Stitch account ID and the ID of the data source you want to replicate to be used in the asset or operation configuration. These can be found by navigating to the data source in the Stitch UI and looking at the URL. For example, if the URL is `https://app.stitchdata.com/client/12345/pipeline/v2/sources/67890/summary`, then the account ID is `12345` and the data source ID is `67890`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dagster-stitch"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     { name = "Mark Snidal", email = "mark.snidal@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.7"
 dependencies = [
     "dagster~=1.1.19",
+    "parse~=1.19.0"
 ]
 
 [project.optional-dependencies]

--- a/src/dagster_stitch/resources.py
+++ b/src/dagster_stitch/resources.py
@@ -93,9 +93,9 @@ class StitchResource:
                 )
                 response.raise_for_status()
 
-                if 'application/json' not in response.headers.get('Content-Type', ''):
+                if "application/json" not in response.headers.get("Content-Type", ""):
                     return response.text
-                
+
                 response_json = response.json()
                 if type(response_json) is not dict:
                     return response_json
@@ -225,7 +225,10 @@ class StitchResource:
         if "error" in response:
             raise Failure(response["error"])
 
-        self._log.info(f"Started replication job for data source {data_source_id} with job_id {response['job_name']}")
+        self._log.info(
+            f"Started replication job for data source {data_source_id} with job_id"
+            f" {response['job_name']}"
+        )
         return response
 
     def get_extractions(self, data_source_id: Optional[int] = None) -> dict:
@@ -248,7 +251,7 @@ class StitchResource:
             return extraction_map.get(data_source_id, {})
         else:
             return extraction_map
-        
+
     def get_extraction_logs(self, extraction_job_name: str) -> dict:
         """Retrieves logs for an extraction job and parses out relevant information
 
@@ -257,16 +260,19 @@ class StitchResource:
 
         Args:
             extraction_job_name (str): The name of the extraction job to get logs for.
-        
+
         Returns:
             Dict[str, int]: A dictionary mapping stream names to the number of records replicated for that stream.
         """
-        extraction_logs = self.make_request("GET", f"{self._account_id}/extractions/{extraction_job_name}")
-    
+        extraction_logs = self.make_request(
+            "GET", f"{self._account_id}/extractions/{extraction_job_name}"
+        )
+
         replications = {
-            replication.named["stream_name"]: int(replication.named["count_records"]) for replication in parse.findall(
-                "tap - INFO replicated {count_records} records from \"{stream_name}\" endpoint\n",
-                extraction_logs
+            replication.named["stream_name"]: int(replication.named["count_records"])
+            for replication in parse.findall(
+                'tap - INFO replicated {count_records} records from "{stream_name}" endpoint\n',
+                extraction_logs,
             )
         }
         self._log.info(f"Found singer replications: {replications}")
@@ -342,7 +348,10 @@ class StitchResource:
                 )
                 break
 
-            if extraction_timeout and (datetime.utcnow() - extraction_start).total_seconds() > extraction_timeout:
+            if (
+                extraction_timeout
+                and (datetime.utcnow() - extraction_start).total_seconds() > extraction_timeout
+            ):
                 raise Failure(
                     f"Extraction job for source {data_source_id} timed out after"
                     f" {extraction_timeout} seconds"

--- a/src/dagster_stitch/utils.py
+++ b/src/dagster_stitch/utils.py
@@ -22,7 +22,7 @@ class BearerAuth(requests.auth.AuthBase):
         return r
 
 
-def get_stitch_connector_url(account_id: str, data_source_id: str, stream_id: str = None) -> str:
+def get_stitch_connector_url(account_id: str, data_source_id: str, stream_id: str = None, stream_name: str = None) -> str:
     """Get the Stitch connector URL from the environment.
 
     Args:
@@ -36,7 +36,7 @@ def get_stitch_connector_url(account_id: str, data_source_id: str, stream_id: st
     base_url = f"https://app.stitchdata.com/client/{account_id}/pipeline/connections/{data_source_id}/data/"
 
     if stream_id:
-        return f"{base_url}properties/{stream_id}/assignees/"
+        return f"{base_url}properties/{stream_id}/{stream_name}/"
     return base_url
 
 
@@ -60,7 +60,7 @@ def generate_materializations(
     for stream_id, stream_properties in stitch_output.stream_schema.items():
         stream_name = stream_properties["name"]
 
-        stream_url = get_stitch_connector_url(account_id, data_source_id, stream_id)
+        stream_url = get_stitch_connector_url(account_id, data_source_id, stream_id, stream_name)
         # TODO: Asset key prefix diff?
 
         metadata = {"connector_url": MetadataValue.url(stream_url)}

--- a/src/dagster_stitch/utils.py
+++ b/src/dagster_stitch/utils.py
@@ -22,7 +22,9 @@ class BearerAuth(requests.auth.AuthBase):
         return r
 
 
-def get_stitch_connector_url(account_id: str, data_source_id: str, stream_id: str = None, stream_name: str = None) -> str:
+def get_stitch_connector_url(
+    account_id: str, data_source_id: str, stream_id: str = None, stream_name: str = None
+) -> str:
     """Get the Stitch connector URL from the environment.
 
     Args:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -15,6 +15,7 @@ from utils import (
     STREAM_NAME,
     DATA_SOURCE_NAME,
     get_extraction_response,
+    get_extraction_logs_response,
     get_sources_response,
     get_list_loads_response,
     get_list_streams_response,
@@ -178,6 +179,14 @@ def test_start_replication_job_and_poll(failure_stage):
 
         if failure_stage not in ["start", "extract"]:
             # List streams
+            extraction_logs_response = get_extraction_logs_response()
+            response_mock.add(
+                responses.GET,
+                f"https://api.stitchdata.com/v4/{ACCOUNT_ID}/extractions/{JOB_ID}",
+                body=get_extraction_logs_response(),
+                content_type="application/octet-stream",
+            )
+
             list_stream_response = get_list_streams_response()
             response_mock.add(
                 responses.GET,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,32 +24,53 @@ def mock_sync_requests(response_mock):
         responses.GET,
         f"https://api.stitchdata.com/v4/sources/{DATA_SOURCE_ID}",
         json={"name": DATA_SOURCE_NAME},
+        content_type="application/json",
     )
     response_mock.add(
         responses.POST,
         f"https://api.stitchdata.com/v4/sources/{DATA_SOURCE_ID}/sync",
         json={"job_name": JOB_ID},
+        content_type="application/json",
     )
     response_mock.add(
         responses.GET,
         f"https://api.stitchdata.com/v4/{ACCOUNT_ID}/extractions",
         json=get_extraction_response(),
+        content_type="application/json",
+    )
+    response_mock.add(
+        responses.GET,
+        f"https://api.stitchdata.com/v4/{ACCOUNT_ID}/extractions/{JOB_ID}",
+        body=get_extraction_logs_response(),
+        content_type="application/octet-stream",
     )
     response_mock.add(
         responses.GET,
         f"https://api.stitchdata.com/v4/sources/{DATA_SOURCE_ID}/streams",
         json=get_list_streams_response(),
+        content_type="application/json",
     )
     response_mock.add(
         responses.GET,
         f"https://api.stitchdata.com/v4/{ACCOUNT_ID}/loads",
         json=get_list_loads_response(),
+        content_type="application/json",
     )
     response_mock.add(
         responses.GET,
         f"https://api.stitchdata.com/v4/sources/{DATA_SOURCE_ID}/streams/{STREAM_ID}",
         json=get_stream_schema_response(),
+        content_type="application/json",
     )
+
+
+def get_extraction_logs_response():
+    return f"""
+        2023-02-23 05:14:22,577Z    tap - INFO replicated 2 records from "{DATA_SOURCE_NAME}" endpoint
+        2023-02-23 05:14:22,578Z    tap - INFO Final url is: https://this-is-a-url.com
+        2023-02-23 05:14:22,578Z    tap - WARN Random nonsense log line
+        2023-02-23 05:14:22,578Z target - INFO Serializing batch with 2 messages for table issue_events
+        """
 
 
 def get_extraction_response(failure=False):


### PR DESCRIPTION
* Add extraction log endpoint to resources to parse out which streams actually have new rows and will be loaded
* Improve load wait logic to incorporate above - is now at least materializing assets after running through locally!
* Standardize timezone to UTC and fixes time compare in polling logic
* Misc. improvements and bugfixes

Fixes for at least a subset of cases #4 and solves #5!