### PR TITLE
Steram asset table types, logging improvements, misc. fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,15 @@ stitch_instance = stitch_resource.configured(
         "account_id": 12345,
     }
 )
-
 stitch_assets = build_stitch_assets(
     data_source_id=54321,
-    destination_tables=["table_name"],
-    resource_defs={"stitch": stitch_instance},
+    destination_tables=["data_source_name.table_name"]
+)
+
+definitions = Definitions(
+    assets=stitch_assets,
+    resources={"stitch": stitch_instance},
 )
 ```
+
+Note that you should include your data source name prefixed by a point in your `destination_tables` and if the table do not correspond to a materialized asset, the materialization will raise an error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dagster-stitch"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
     { name = "Mark Snidal", email = "mark.snidal@gmail.com" },
 ]

--- a/src/dagster_stitch/ops.py
+++ b/src/dagster_stitch/ops.py
@@ -67,7 +67,7 @@ def replicate_data_source_op(context):
     )
 
     if context.op_config["yield_materializations"]:
-        asset_key_prefix = context.op_config["asset_key_prefix"]
+        asset_key_prefix = [context.op_config["asset_key_prefix"]]
         yield from generate_materializations(sync_request, asset_key_prefix)
 
     # Yield the sync status

--- a/tests/test_asset_defs.py
+++ b/tests/test_asset_defs.py
@@ -1,4 +1,3 @@
-import pytest
 import responses
 
 from dagster import AssetKey, materialize_to_memory
@@ -10,7 +9,6 @@ from utils import (
     DATA_SOURCE_NAME,
     API_KEY,
     ACCOUNT_ID,
-    STREAM_ID,
     STREAM_NAME,
     mock_sync_requests,
 )

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,7 +1,6 @@
-import pytest
 import responses
 
-from dagster import op, job, AssetKey
+from dagster import job, AssetKey
 from dagster_stitch import stitch_resource, replicate_data_source_op, StitchOutput
 
 from utils import (
@@ -9,7 +8,6 @@ from utils import (
     ACCOUNT_ID,
     API_KEY,
     DATA_SOURCE_ID,
-    STREAM_ID,
     DATA_SOURCE_NAME,
     STREAM_NAME,
 )
@@ -46,6 +44,6 @@ def test_replicate_data_source_op():
         )
         assert asset_keys == set(
             [
-                AssetKey([f"stitch_{DATA_SOURCE_NAME}", STREAM_NAME]),
+                AssetKey(["stitch", DATA_SOURCE_NAME, STREAM_NAME]),
             ]
         )

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,5 +1,3 @@
-import dagster_stitch
-
 import pytest
 import responses
 
@@ -38,7 +36,8 @@ def test_start_replication_job():
             json=json_response,
         )
 
-        assert resource.start_replication_job(DATA_SOURCE_ID) == json_response
+        actual_response, _ = resource.start_replication_job(DATA_SOURCE_ID)
+        assert actual_response == json_response, "Replication job did not produce expected result."
 
 
 @pytest.mark.parametrize("max_retries,actual_retries", [(2, 1), (2, 3), (4, 4)])
@@ -73,7 +72,8 @@ def test_get_replication_job_retries(max_retries: int, actual_retries: int):
             return resource.start_replication_job(DATA_SOURCE_ID)
 
     if actual_retries < max_retries:
-        assert _mock_response() == json_response
+        mock_response, _ = _mock_response()
+        assert mock_response == json_response
     else:
         with pytest.raises(Failure):
             _mock_response()
@@ -144,7 +144,7 @@ def test_get_stream_schema():
         )
 
         stream_schema = resource.get_stream_schema(DATA_SOURCE_ID, STREAM_NAME)
-        assert stream_schema == {"schema": ["author", "description"]}
+        assert stream_schema == {"schema": {"author": "integer", "description": "string"}}
 
 
 @pytest.mark.parametrize("failure_stage", ["start", "extract", None])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,12 +65,10 @@ def mock_sync_requests(response_mock):
 
 
 def get_extraction_logs_response():
-    return f"""
-        2023-02-23 05:14:22,577Z    tap - INFO replicated 2 records from "{DATA_SOURCE_NAME}" endpoint
-        2023-02-23 05:14:22,578Z    tap - INFO Final url is: https://this-is-a-url.com
-        2023-02-23 05:14:22,578Z    tap - WARN Random nonsense log line
-        2023-02-23 05:14:22,578Z target - INFO Serializing batch with 2 messages for table issue_events
-        """
+    return f"""2023-02-23 05:14:22,577Z    tap - INFO replicated 2 records from "{DATA_SOURCE_NAME}" endpoint
+2023-02-23 05:14:22,578Z    tap - INFO Final url is: https://this-is-a-url.com
+2023-02-23 05:14:22,578Z    tap - WARN Random nonsense log line
+2023-02-23 05:14:22,578Z target - INFO Serializing batch with 2 messages for table issue_events"""
 
 
 def get_extraction_response(failure=False):
@@ -215,8 +213,8 @@ def get_list_loads_response(loaded_at: datetime.datetime = None):
 def get_stream_schema_response():
     return {
         "schema": (
-            '{"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type":'
-            ' "string"}}}'
+            '{"type": "object", "properties": {"author": {"type": ["integer"]}, "description":'
+            ' {"type": ["null", "string"]}}}'
         ),
         "metadata": [
             {


### PR DESCRIPTION
* Add types to output tables, parsing the Stitch stream output JSON
* Better asset prefix handling, and clarify use in README
* Load timestamp fix to use the end of extraction fixing a hang if the loads processed very quickly
* Reduce duplicative logging, logging only once for errors instead of every poll etc.
* Misc. fixes